### PR TITLE
Fixed build issue in tester, added set_step_callback to Python bindings.

### DIFF
--- a/tests/tester.cpp
+++ b/tests/tester.cpp
@@ -120,7 +120,7 @@ public:
         va_end(args);
 
         char buff2[max_line_size];
-        std::snprintf(buff2, max_line_size, "%2u %*s%s",
+        std::snprintf(buff2, max_line_size, "%2u %*s%.800s",
                       static_cast<unsigned>(ticks),
                       static_cast<int>(level * 2), "", buff);
 

--- a/z80/_z80module.cpp
+++ b/z80/_z80module.cpp
@@ -100,6 +100,23 @@ public:
         return old_callback;
     }
 
+    void on_step() {
+        base::on_step();
+
+        PyObject *result = PyObject_CallObject(on_step_callback, nullptr);
+        decref_guard result_guard(result);
+
+        if(!result) {
+            assert(0);  // TODO: stop();
+        }
+    }
+
+    PyObject *set_step_callback(PyObject *callback) {
+        PyObject *old_callback = on_step_callback;
+        on_step_callback = callback;
+        return old_callback;
+    }
+
     fast_u8 on_get_b() const { return state.b; }
     void on_set_b(fast_u8 n) { state.b = n; }
 
@@ -218,6 +235,7 @@ public:
         std::swap(state.l, state.alt_l);
     }
 
+
 #if 0  // TODO
     void on_step() {
         fprintf(stderr, "PC=%04x SP=%04x BC=%04x DE=%04x HL=%04x AF=%04x %02x%02x%02x%02x\n",
@@ -241,6 +259,7 @@ protected:
 private:
     machine_state state;
     PyObject *on_input_callback = nullptr;
+    PyObject *on_step_callback = nullptr;
 };
 
 namespace i8080_machine {

--- a/z80/machine.inc
+++ b/z80/machine.inc
@@ -124,6 +124,23 @@ static PyObject *set_input_callback(PyObject *self, PyObject *args) {
     Py_RETURN_NONE;
 }
 
+static PyObject *set_step_callback(PyObject *self, PyObject *args) {
+    PyObject *new_callback;
+    if(!PyArg_ParseTuple(args, "O:set_callback", &new_callback))
+        return nullptr;
+
+    if(!PyCallable_Check(new_callback)) {
+        PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+        return nullptr;
+    }
+
+    auto &machine = cast_machine(self);
+    PyObject *old_callback = machine.set_step_callback(new_callback);
+    Py_XINCREF(new_callback);
+    Py_XDECREF(old_callback);
+    Py_RETURN_NONE;
+}
+
 static PyObject *run(PyObject *self, PyObject *args) {
     auto &machine = cast_machine(self);
     z80::events_mask::type events = machine.on_run();
@@ -148,6 +165,10 @@ static PyMethodDef methods[] = {
      "processing on reading, writing or executing them."},
     {"set_input_callback", set_input_callback, METH_VARARGS,
      "Set a callback function handling reading from ports."},
+    {"set_step_callback", set_step_callback, METH_VARARGS,
+     "Set a callback function handling stepping of the processor. "
+     "The callback will be invoked after the side-effects of the "
+     "current instruction have taken place"},
     {"run", run, METH_NOARGS,
      "Run emulator until one or several events are signaled."},
 #if defined(Z80_MACHINE)


### PR DESCRIPTION
Hello!

Thanks for this great project!

I intend to use your simulator as a reference implementation to compare it to my work, but in order to do so, I needed to add a new Python callback option to hook on_step.

Would you mind merging the change into your own repo?

Thanks,
Andras
