### PR TITLE
Fixed block IN decrementing B too early

### DIFF
--- a/tests/tests_z80
+++ b/tests/tests_z80
@@ -1850,11 +1850,11 @@ edb2 inir
  8 get_h 00
  8 get_f 00
  8 fetch_cycle_extra_1t
- 9 input at ff00
- 9   set_addr_bus 0001 -> ff00
-12   iorq_wait ff00
+ 9 input at 0000
+ 9   set_addr_bus 0001 -> 0000
+12   iorq_wait 0000
 13 write ed -> ff at 0000
-13   set_addr_bus ff00 -> 0000
+13   set_addr_bus 0000 -> 0000
 15   mreq_wait 0000
 16 set_c 00 -> 00
 16 set_b 00 -> ff

--- a/z80.h
+++ b/z80.h
@@ -3598,8 +3598,8 @@ public:
         fast_u8 f = self().on_get_f();
 
         self().on_fetch_cycle_extra_1t();
-        bc = sub16(bc, 0x0100);
         fast_u8 r = self().on_input_cycle(bc);
+        bc = sub16(bc, 0x0100);
         self().on_write_cycle(hl, r);
         fast_u8 s = get_high8(bc);
 


### PR DESCRIPTION
INI/IND/INIR/INDR all read from the port before decrementing B.

Visual Z80 remix also confirms that B is decremented after BC is put on the address bus.