### PR TITLE
Python callbacks: read, write, reti, int mode 2 vector

### DIFF
--- a/z80.h
+++ b/z80.h
@@ -225,6 +225,7 @@ public:
     unsigned on_get_int_mode() const { return 0; }
     void on_set_int_mode(unsigned mode) { unused(mode); }
     void on_set_is_int_disabled(bool f) { unused(f); }
+    fast_u8 on_get_int_vector() { return 0xFF; }
 
     void set_i_on_ld(fast_u8 i) { self().on_set_i(i); }
 
@@ -3771,7 +3772,7 @@ private:
                 break;
             case 2: {
                 // ack(7) w(3) w(3) r(3) r(3)
-                fast_u16 vector_addr = make16(self().on_get_i(), 0xff);
+                fast_u16 vector_addr = make16(self().on_get_i(), self().on_get_int_vector());
                 fast_u8 lo = self().on_read_cycle(vector_addr);
                 fast_u8 hi = self().on_read_cycle(inc16(vector_addr));
                 isr_addr = make16(hi, lo); }

--- a/z80/machine.inc
+++ b/z80/machine.inc
@@ -197,6 +197,40 @@ static PyObject *unmark_addrs(PyObject *self, PyObject *args) {
     Py_RETURN_NONE;
 }
 
+static PyObject *set_read_callback(PyObject *self, PyObject *args) {
+    PyObject *new_callback;
+    if(!PyArg_ParseTuple(args, "O:set_callback", &new_callback))
+        return nullptr;
+
+    if(!PyCallable_Check(new_callback)) {
+        PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+        return nullptr;
+    }
+
+    auto &machine = cast_machine(self);
+    PyObject *old_callback = machine.set_read_callback(new_callback);
+    Py_XINCREF(new_callback);
+    Py_XDECREF(old_callback);
+    Py_RETURN_NONE;
+}
+
+static PyObject *set_write_callback(PyObject *self, PyObject *args) {
+    PyObject *new_callback;
+    if(!PyArg_ParseTuple(args, "O:set_callback", &new_callback))
+        return nullptr;
+
+    if(!PyCallable_Check(new_callback)) {
+        PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+        return nullptr;
+    }
+
+    auto &machine = cast_machine(self);
+    PyObject *old_callback = machine.set_write_callback(new_callback);
+    Py_XINCREF(new_callback);
+    Py_XDECREF(old_callback);
+    Py_RETURN_NONE;
+}
+
 static PyObject *set_input_callback(PyObject *self, PyObject *args) {
     PyObject *new_callback;
     if(!PyArg_ParseTuple(args, "O:set_callback", &new_callback))
@@ -226,6 +260,40 @@ static PyObject *set_output_callback(PyObject *self, PyObject *args) {
 
     auto &machine = cast_machine(self);
     PyObject *old_callback = machine.set_output_callback(new_callback);
+    Py_XINCREF(new_callback);
+    Py_XDECREF(old_callback);
+    Py_RETURN_NONE;
+}
+
+static PyObject *set_reti_callback(PyObject *self, PyObject *args) {
+    PyObject *new_callback;
+    if(!PyArg_ParseTuple(args, "O:set_callback", &new_callback))
+        return nullptr;
+
+    if(!PyCallable_Check(new_callback)) {
+        PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+        return nullptr;
+    }
+
+    auto &machine = cast_machine(self);
+    PyObject *old_callback = machine.set_reti_callback(new_callback);
+    Py_XINCREF(new_callback);
+    Py_XDECREF(old_callback);
+    Py_RETURN_NONE;
+}
+
+static PyObject *set_get_int_vector_callback(PyObject *self, PyObject *args) {
+    PyObject *new_callback;
+    if(!PyArg_ParseTuple(args, "O:set_callback", &new_callback))
+        return nullptr;
+
+    if(!PyCallable_Check(new_callback)) {
+        PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+        return nullptr;
+    }
+
+    auto &machine = cast_machine(self);
+    PyObject *old_callback = machine.set_get_int_vector_callback(new_callback);
     Py_XINCREF(new_callback);
     Py_XDECREF(old_callback);
     Py_RETURN_NONE;
@@ -281,10 +349,18 @@ static PyMethodDef methods[] = {
     {"unmark_addrs", unmark_addrs, METH_VARARGS,
      "Clear the marking on a range of memory bytes that indicates it requires custom "
      "processing on reading, writing or executing them."},
+    {"set_read_callback", set_read_callback, METH_VARARGS,
+     "Set a callback function handling reading from memory."},
+    {"set_write_callback", set_write_callback, METH_VARARGS,
+     "Set a callback function handling writing to memory."},
     {"set_input_callback", set_input_callback, METH_VARARGS,
      "Set a callback function handling reading from ports."},
     {"set_output_callback", set_output_callback, METH_VARARGS,
      "Set a callback function handling writing to ports."},
+    {"set_reti_callback", set_reti_callback, METH_VARARGS,
+     "Set a callback function handling the reti instruction."},
+    {"set_get_int_vector_callback", set_get_int_vector_callback, METH_VARARGS,
+     "Set a callback function handling the interrupt mode 2 vector address."},
     {"run", run, METH_NOARGS,
      "Run emulator until one or several events are signaled."},
 #if defined(Z80_MACHINE)


### PR DESCRIPTION
Added:

- Python callback for memory reads (same format as input callback)
- Python callback for memory writes (same format as output callback)
- Python callback for RETI instruction. The added override to "on_reti" function always invokes base::on_reti, but also calls the on_reti Python handler if registered. The handler is called after the base function to ensure processor state reflects the RETI operation.
- Python callback for fetching the lower byte of interrupt mode 2 vector address. A "on_get_int_vector" function was added to one of the base classes (completely guessed which was the best class, please feel free to reorganize) with a default value of 0xFF to reflect was the previous default was.  Then Python callback was added.

I tested these in the VM (which heavily uses all of this functionality) and it looks like it's stable.  Thanks!